### PR TITLE
Improve support for jinja by updating url kwarg name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Boilerplate:
 
 ### Security
 -->
+## v2.2.0 (2015-08-24)
+
+- Improve jinja2 support
+- Add Code of Conduct
+- Add contributors attribution
+
 ## v2.1.2 (2015-08-24)
 
 - Fix version of mptt

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at techinfo@gsdesign.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,5 @@
+# Authors
+- [Ryan Senkbeil](https://github.com/rsenk330)
+
+# Contributors
+- [Chris Erickson](https://github.com/chris-erickson)

--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of rio nor the names of its
+* Neither the name of django-leaf nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 
@@ -25,4 +25,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/leaf/__init__.py
+++ b/leaf/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '2.1.2'
+__version__ = '2.2.0'
 default_app_config = 'leaf.apps.LeafConfig'

--- a/leaf/page.py
+++ b/leaf/page.py
@@ -97,7 +97,7 @@ def get_url(view):
     if getattr(view, 'url', None):
         return view.url
 
-    url = view.kwargs.get('url', None)
+    url = view.kwargs.get('leaf_url', None)
     if url is None:
         raise Http404("URL not provided as class argument or kwarg")
 

--- a/leaf/urls.py
+++ b/leaf/urls.py
@@ -3,5 +3,5 @@ from django.conf.urls import url
 from .views import LeafTemplateView
 
 urlpatterns = [
-    url(r'(?P<url>.*)(/)?$', LeafTemplateView.as_view(), name='page'),
+    url(r'(?P<leaf_url>.*)(/)?$', LeafTemplateView.as_view(), name='page'),
 ]

--- a/leaf/views.py
+++ b/leaf/views.py
@@ -18,7 +18,7 @@ class LeafTemplateView(TemplateView):
         was a 404, try the request again with the trailing slash.
 
         """
-        self.page = page.get_from_database(kwargs.get('url'))
+        self.page = page.get_from_database(kwargs.get('leaf_url'))
 
         try:
             return super(LeafTemplateView, self).dispatch(request, *args, **kwargs)


### PR DESCRIPTION
This improves support for using leaf with jinja.  URL kwargs end up in the context in jinja differently than with django templates.  In this case, the `url` kwarg was overwriting a custom `url` extension.  Changing the `url` extension would also be a solution, but that's a departure from what most django users are familiar with.  The best solution seems to be to effectively namespace the url kwarg so that it won't collide with anything.

Here's the jinja context after the change:

```
>>> locals()
{'asdasdadsd': Undefined, 'absolute_url': <function absolute_url at 0x7eff1c3e5bf8>, 'page': None, 'range': <class 'range'>, 'csrf_token': <django.utils.functional.lazy.<locals>.__proxy__ object at 0x7eff17fff198>, 'cycler': <class 'jinja2.utils.Cycler'>, 'datetime': <class 'datetime.datetime'>, 'view': <leaf.views.LeafTemplateView object at 0x7eff17fff438>, 'csrf_input': <django.utils.functional.lazy.<locals>.__proxy__ object at 0x7eff17fff470>, 'joiner': <class 'jinja2.utils.Joiner'>, 'lipsum': <function generate_lorem_ipsum at 0x7eff1c3d31e0>, 'gettext': <function ugettext at 0x7eff221daf28>, 'absolute_root': <function absolute_root at 0x7eff1db77048>, '_': {...}, 'url': <function reverse at 0x7eff21f002f0>, 'request': <WSGIRequest: GET '/about/locations/?__debugger__=yes&cmd=locals()&frm=139634083962776&s=fHyv971G2l2VThgHo8ar'>, 'dict': <class 'dict'>, 'get_expert_for_key': <function get_expert_for_key at 0x7eff1c0966a8>, 'ngettext': <function ungettext at 0x7eff221e7048>, 'leaf_url': 'about/locations/', 'static': <bound method StaticFilesStorage.url of <django.contrib.staticfiles.storage.StaticFilesStorage object at 0x7eff1c412518>>}
```

Note that `url` is normally a function, and `leaf_url` is a string.

@rsenk330 I'm sure this is pretty far off your radar these days, but maybe you're feeling nostalgic.
