### PR TITLE
add try/except around reference to '_deferred' attribute

### DIFF
--- a/leaf/models.py
+++ b/leaf/models.py
@@ -21,8 +21,14 @@ class PageBase(models.base.ModelBase):
     def __init__(cls, name, bases, dct):
         super(PageBase, cls).__init__(name, bases, dct)
 
-        if cls._deferred:
-            return
+        # Dj < 1.10
+        try:
+            if cls._deferred:
+                return
+        # Dj >= 1.10
+        except AttributeError:
+            if cls is models.DEFERRED:
+                return
 
         if not cls._meta.abstract:
             if not getattr(cls, 'identifier', None):


### PR DESCRIPTION
Add try/except around reference to '_deferred' attribute, which no longer exists in Django 1.10.  "Except" branch handles the issue according to the new way. Cf https://github.com/gadventures/django-fsm-admin/issues/61